### PR TITLE
Return `class_name` in `name` method

### DIFF
--- a/lib/minitest/sub_test_case.rb
+++ b/lib/minitest/sub_test_case.rb
@@ -15,6 +15,10 @@ module Minitest
           super(re) - parent_test_case.methods_matching(re)
         end
 
+        define_singleton_method(:name) do
+          class_name
+        end
+
         define_method(:location) do
           loc = " [#{self.failure.location}]" unless passed? or error?
           "#{self.class.class_name}##{self.name}#{loc}"

--- a/lib/minitest/sub_test_case.rb
+++ b/lib/minitest/sub_test_case.rb
@@ -19,6 +19,7 @@ module Minitest
           class_name
         end
 
+        # NOTE: `location` method needs only for support of Minitest < 5.11.
         define_method(:location) do
           loc = " [#{self.failure.location}]" unless passed? or error?
           "#{self.class.class_name}##{self.name}#{loc}"


### PR DESCRIPTION
Since Minitest v5.11, location method use from `Minitest::Result`.
Result name generate from Runnable's name.
https://github.com/seattlerb/minitest/blob/b0069391486373e8b7553c71b330cce54d2915be/lib/minitest.rb#L466

So override name method for getting the correct class name.